### PR TITLE
Run check nhs number when DDS is not enabled

### DIFF
--- a/helm/auth_service/apis/initialise/onOrchResponse.js
+++ b/helm/auth_service/apis/initialise/onOrchResponse.js
@@ -61,7 +61,7 @@ module.exports = function(responseObj, request, forwardToMS, sendResponse, getJW
       console.log('openehr response: ' + JSON.stringify(openehrResponse, null, 2));
 
       // is DDS configured for use?
-      if (!globalConfig.DDS || !globalConfig.DDS.enabled) {
+      if (!global_config.DDS || !global_config.DDS.enabled) {
         return sendResponse({
           ok: true,
           mode: 'secure'

--- a/helm/auth_service/apis/initialise/onOrchResponse.js
+++ b/helm/auth_service/apis/initialise/onOrchResponse.js
@@ -23,7 +23,7 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
-  7 February 2019
+  27 March 2019
 
 */
 
@@ -39,32 +39,14 @@ module.exports = function(responseObj, request, forwardToMS, sendResponse, getJW
 
   console.log('onOrchResponse for /api/initialise');
 
+  var global_config = require('/opt/qewd/mapped/configuration/global_config.json');
   var response = responseObj.message;
   console.log('** response = ' + JSON.stringify(response, null, 2));
-
-  // is DDS configured for use?
-
-  var global_config = require('/opt/qewd/mapped/configuration/global_config.json');
-  if (!global_config.DDS) {
-
-    if (!response.error && response.authenticated) {
-      sendResponse({
-        ok: true,
-        mode: 'secure'
-      });
-      return true;
-    }
-    // otherwise return original response unchanged
-
-    return;
-  }
-
-  // DDS is in use:
 
   var message;
 
   if (!response.error && response.authenticated) {
-    console.log('** no error, but authenticated, so redirect to DDS to fetch new data');
+    console.log('** no error, but authenticated');
 
     message = {
       path: '/api/openehr/check',
@@ -77,6 +59,16 @@ module.exports = function(responseObj, request, forwardToMS, sendResponse, getJW
       //  after handler /openehr_service/ddsUpdateCheck/index.js
 
       console.log('openehr response: ' + JSON.stringify(openehrResponse, null, 2));
+
+      // is DDS configured for use?
+      if (!globalConfig.DDS || !globalConfig.DDS.enabled) {
+        return sendResponse({
+          ok: true,
+          mode: 'secure'
+        });
+      }
+
+      // DDS is in use
 
       var recordStatus;
       var new_patient;
@@ -110,11 +102,11 @@ module.exports = function(responseObj, request, forwardToMS, sendResponse, getJW
 
       else if (recordStatus === 'ready') {
 
-        // pre-fetch the demographics from DDS now 
+        // pre-fetch the demographics from DDS now
         // to avoid later race conditions and speed up UI later
 
         // note the dummy patient Id - this is because the actual
-        // patient Id is picked up in the handler function 
+        // patient Id is picked up in the handler function
         // from the JWT
         //  ie the patientId in the path is ignored
 
@@ -155,6 +147,5 @@ module.exports = function(responseObj, request, forwardToMS, sendResponse, getJW
 
   // implicitly for errors or unautenticated responses,
   // response will be returned to browser unchanged
-
 
 };

--- a/helm/configuration/global_config.json
+++ b/helm/configuration/global_config.json
@@ -30,6 +30,7 @@
     "logout_approach": "client"
   },
   "DDS": {
+    "enabled": true,
     "auth": {
       "host": "https://devauth.discoverydataservice.net",
       "path": "/auth/realms/endeavour/protocol/openid-connect/token",

--- a/helm/openehr_service/apis/checkNhsNumber/onMSResponse.js
+++ b/helm/openehr_service/apis/checkNhsNumber/onMSResponse.js
@@ -23,7 +23,7 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
-  16 March 2019
+  27 March 2019
 
 */
 
@@ -41,6 +41,13 @@ const { ExtraHeading, Heading, RecordStatus } = require('../../lib/shared/enums'
  * @return {bool}
  */
 module.exports = function (message, jwt, forward, sendBack) { // eslint-disable-line no-unused-vars
+  const globalConfig = this.userDefined.globalConfig;
+
+  // is DDS configured for use?
+  if (!globalConfig.DDS || !globalConfig.DDS.enabled) {
+    return false;
+  }
+
   /*
 
     Handling the response from /api/openehr/check  (ie response from index.js in this folder)
@@ -92,7 +99,7 @@ module.exports = function (message, jwt, forward, sendBack) { // eslint-disable-
     return false;
   }
 
-  const synopsisConfig = this.userDefined.globalConfig.openehr.synopsis;
+  const synopsisConfig = globalConfig.openehr.synopsis;
   logger.debug('synopsis headings:', { headings: synopsisConfig.headings });
 
   // this is the first poll request using /api/initialise by the user, so

--- a/helm/openehr_service/spec/support/configuration.json
+++ b/helm/openehr_service/spec/support/configuration.json
@@ -4,6 +4,9 @@
       "oidc_server": "http://oidc.ripple.foundation:8000"
     }
   },
+  "DDS": {
+    "enabled": true
+  },
   "openehr": {
     "servers": {
       "marand": {

--- a/helm/openehr_service/spec/unit/apis/checkNhsNumber/onMSResponse.spec.js
+++ b/helm/openehr_service/spec/unit/apis/checkNhsNumber/onMSResponse.spec.js
@@ -24,7 +24,7 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
- 16 March 2019
+ 27 March 2019
 
 */
 
@@ -82,11 +82,30 @@ describe('apis/onMsResponse', () => {
     mockery.deregisterAll();
   });
 
+  it('should do nothing when DDS missed', () => {
+    delete q.userDefined.globalConfig.DDS
+
+    const actual = onMsResponse.call(q, message, forward, sendBack);
+
+    expect(DiscoveryDispatcher).not.toHaveBeenCalled();
+    expect(actual).toBe(false);
+  });
+
+  it('should do nothing when DDS not enabled', () => {
+    q.userDefined.globalConfig.DDS.enabled = false;
+
+    const actual = onMsResponse.call(q, message, forward, sendBack);
+
+    expect(DiscoveryDispatcher).not.toHaveBeenCalled();
+    expect(actual).toBe(false);
+  });
+
   it('should do nothing when status is ready', () => {
     message.status = 'ready';
 
     const actual = onMsResponse.call(q, message, forward, sendBack);
 
+    expect(DiscoveryDispatcher).not.toHaveBeenCalled();
     expect(actual).toBe(false);
   });
 
@@ -95,6 +114,7 @@ describe('apis/onMsResponse', () => {
 
     const actual = onMsResponse.call(q, message, forward, sendBack);
 
+    expect(DiscoveryDispatcher).not.toHaveBeenCalled();
     expect(actual).toBe(false);
   });
 


### PR DESCRIPTION
@robtweed Please review this PR

1. A new property is added to DDS configuration - `enabled`. It's `true` by default.
2. When `DDS.enabled` is `false` or `DDS` section is missed - no loading discovery data