### PR TITLE
Update phr feeds logic to use nhsNumber instead of email

### DIFF
--- a/helm/openehr_service/lib/commands/getFeedDetail.js
+++ b/helm/openehr_service/lib/commands/getFeedDetail.js
@@ -23,14 +23,14 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
-  16 March 2019
+  9 April 2019
 
 */
 
 'use strict';
 
 const { BadRequestError } = require('../errors');
-const debug = require('debug')('helm:openehr:commands:get-feed-detail');
+const { logger } = require('../core');
 
 class GetFeedDetailCommand {
   constructor(ctx) {
@@ -42,14 +42,14 @@ class GetFeedDetailCommand {
    * @return {Promise.<Object>}
    */
   async execute(sourceId) {
-    debug('sourceId: %s', sourceId);
+    logger.info('commands/getFeedDetail', { sourceId });
 
     if (!sourceId || sourceId === '') {
       throw new BadRequestError('Missing or empty sourceId');
     }
 
     const { phrFeedService } = this.ctx.services;
-    const responseObj = await phrFeedService.getBySourceId(sourceId);
+    const responseObj = phrFeedService.getBySourceId(sourceId);
 
     return {
       feed: responseObj

--- a/helm/openehr_service/lib/commands/getFeedsSummary.js
+++ b/helm/openehr_service/lib/commands/getFeedsSummary.js
@@ -23,13 +23,13 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
-  16 March 2019
+  9 April 2019
 
 */
 
 'use strict';
 
-const debug = require('debug')('helm:openehr:commands:get-feeds-summary');
+const { logger } = require('../core');
 
 class GetFeedsSummaryCommand {
   constructor(ctx, session) {
@@ -38,13 +38,14 @@ class GetFeedsSummaryCommand {
   }
 
   /**
-   * @return {Promise.<Object[]>}
+   * @return {Promise.<Object>}
    */
   async execute() {
-    debug('execute get feeds summary');
+    logger.info('commands/getFeedsSummary');
 
     const { phrFeedService } = this.ctx.services;
-    const responseObj = await phrFeedService.getByEmail(this.session.email);
+    const nhsNumber = this.session.nhsNumber;
+    const responseObj = phrFeedService.getByNhsNumber(nhsNumber);
 
     return {
       feeds: responseObj

--- a/helm/openehr_service/lib/commands/getPatientHeadingSynopsis.js
+++ b/helm/openehr_service/lib/commands/getPatientHeadingSynopsis.js
@@ -23,7 +23,7 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
-  16 March 2019
+  9 April 2019
 
 */
 
@@ -31,7 +31,7 @@
 
 const { BadRequestError } = require('../errors');
 const { isHeadingValid, isPatientIdValid } = require('../shared/validation');
-const { Role, Heading } = require('../shared/enums');
+const { Role } = require('../shared/enums');
 const debug = require('debug')('helm:openehr:commands:get-patient-heading-synopsis');
 
 class GetPatientHeadingSynopsisCommand {

--- a/helm/openehr_service/lib/commands/postFeed.js
+++ b/helm/openehr_service/lib/commands/postFeed.js
@@ -23,7 +23,7 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
-  16 March 2019
+  9 April 2019
 
 */
 
@@ -31,7 +31,7 @@
 
 const { BadRequestError } = require('../errors');
 const { isFeedPayloadValid } = require('../shared/validation');
-const debug = require('debug')('helm:openehr:commands:post-feed');
+const { logger } = require('../core');
 
 class PostFeedCommand {
   constructor(ctx, session) {
@@ -44,20 +44,16 @@ class PostFeedCommand {
    * @return {Promise.<Object>}
    */
   async execute(payload) {
-    debug('payload: %j', payload);
+    logger.info('commands/postFeed', { payload });
 
     const valid = isFeedPayloadValid(payload);
     if (!valid.ok) {
       throw new BadRequestError(valid.error);
     }
 
-    const feed = {
-      ...payload,
-      email: this.session.email
-    };
-    debug('create a new feed: %j', feed);
     const { phrFeedService } = this.ctx.services;
-    const sourceId = await phrFeedService.create(feed);
+    const nhsNumber = this.session.nhsNumber;
+    const sourceId = phrFeedService.create(nhsNumber, payload);
 
     return {
       sourceId

--- a/helm/openehr_service/lib/db/phrFeedDb.js
+++ b/helm/openehr_service/lib/db/phrFeedDb.js
@@ -23,14 +23,13 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
-  16 March 2019
+  9 April 2019
 
 */
 
 'use strict';
 
 const { logger } = require('../core');
-const debug = require('debug')('helm:openehr:db:phr-feeds');
 
 class PhrFeedDb {
   constructor(ctx) {
@@ -59,20 +58,20 @@ class PhrFeedDb {
   /**
    * Gets phr feed by name
    *
-   * @param  {string} email
+   * @param  {string|int} nhsNumber
    * @param  {string} name
    * @return {Object|null}
    */
-  getByName(email, name) {
-    logger.info('db/phrFeedDb|getByName', { email, name });
+  getByName(nhsNumber, name) {
+    logger.info('db/phrFeedDb|getByName', { nhsNumber, name });
 
-    const byEmailNode = this.phrFeeds.$(['byEmail', email]);
+    const byNhsNumberNode = this.phrFeeds.$(['by_nhsNumber', nhsNumber]);
     const bySourceIdNode = this.phrFeeds.$('bySourceId');
 
     let dbFeed = null;
 
-    if (byEmailNode.exists) {
-      byEmailNode.forEachChild((sourceId) => {
+    if (byNhsNumberNode.exists) {
+      byNhsNumberNode.forEachChild((sourceId) => {
         const data = bySourceIdNode.$(sourceId).getDocument();
         if (data.name === name) {
           dbFeed = {
@@ -91,20 +90,20 @@ class PhrFeedDb {
   /**
    * Gets phr feed by landing page url
    *
-   * @param  {string} email
+   * @param  {string|int} nhsNumber
    * @param  {string} landingPageUrl
    * @return {Object|null}
    */
-  getByLandingPageUrl(email, landingPageUrl) {
-    logger.info('db/phrFeedDb|getByLandingPageUrl', { email, landingPageUrl });
+  getByLandingPageUrl(nhsNumber, landingPageUrl) {
+    logger.info('db/phrFeedDb|getByLandingPageUrl', { nhsNumber, landingPageUrl });
 
-    const byEmailNode = this.phrFeeds.$(['byEmail', email]);
+    const byNhsNumberNode = this.phrFeeds.$(['by_nhsNumber', nhsNumber]);
     const bySourceIdNode = this.phrFeeds.$('bySourceId');
 
     let dbFeed = null;
 
-    if (byEmailNode.exists) {
-      byEmailNode.forEachChild((sourceId) => {
+    if (byNhsNumberNode.exists) {
+      byNhsNumberNode.forEachChild((sourceId) => {
         const data = bySourceIdNode.$(sourceId).getDocument();
         if (data.landingPageUrl === landingPageUrl) {
           dbFeed = {
@@ -121,37 +120,37 @@ class PhrFeedDb {
   }
 
   /**
-   * Gets phr feeds by email
+   * Gets phr feeds by nhs number
    *
-   * @param  {string} email
+   * @param  {string|int} nhsNumber
    * @return {Object[]}
    */
-  getByEmail(email) {
-    logger.info('db/phrFeedDb|getByEmail', { email });
+  getByNhsNumber(nhsNumber) {
+    logger.info('db/phrFeedDb|getByNhsNumber', { nhsNumber });
 
-    const byEmailNode = this.phrFeeds.$(['byEmail', email]);
+    const byNhsNumberNode = this.phrFeeds.$(['by_nhsNumber', nhsNumber]);
     const bySourceIdNode = this.phrFeeds.$('bySourceId');
 
     const dbFeeds = [];
     const names = {};
     const urls = {};
 
-    if (byEmailNode.exists) {
-      byEmailNode.forEachChild((sourceId) => {
+    if (byNhsNumberNode.exists) {
+      byNhsNumberNode.forEachChild((sourceId) => {
         const dbData = bySourceIdNode.$(sourceId).getDocument();
 
         // duplicate - delete it
         if (names[dbData.name]) {
-          debug('duplicate phr feed found by name', dbData.name);
-          byEmailNode.$(sourceId).delete();
+          logger.debug('duplicate phr feed found by name', { name: dbData.name });
+          byNhsNumberNode.$(sourceId).delete();
           bySourceIdNode.$(sourceId).delete();
           return;
         }
 
         // duplicate found - delete it
         if (urls[dbData.landingPageUrl]) {
-          debug('duplicate phr feed found by landing page url', dbData.landingPageUrl);
-          byEmailNode.$(sourceId).delete();
+          logger.debug('duplicate phr feed found by landing page url', { landingPageUrl: dbData.landingPageUrl });
+          byNhsNumberNode.$(sourceId).delete();
           bySourceIdNode.$(sourceId).delete();
           return;
         }
@@ -178,7 +177,7 @@ class PhrFeedDb {
   insert(data) {
     logger.info('db/phrFeedDb|insert', { data });
 
-    this.phrFeeds.$(['byEmail', data.email, data.sourceId]).value = 'true';
+    this.phrFeeds.$(['by_nhsNumber', data.nhsNumber, data.sourceId]).value = '';
     this.phrFeeds.$(['bySourceId', data.sourceId]).setDocument(data);
   }
 

--- a/helm/openehr_service/lib/services/headingService.js
+++ b/helm/openehr_service/lib/services/headingService.js
@@ -23,7 +23,7 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
-  16 March 2019
+  9 April 2019
 
 */
 
@@ -362,7 +362,7 @@ class HeadingService {
       results
     };
   }
-  
+
   /**
    * @TODO Need to think about refactoring this method to style of all architecture concept
    * @param  {string|int} patientId
@@ -372,15 +372,15 @@ class HeadingService {
    */
   async getLatestTop3ThingsSynopsis(patientId, heading, limit) {
     logger.info('services/headingService|getSynopsis', { patientId, heading, limit });
-  
+
     const { results } = await this.getSummary(patientId, heading);
-    
+
     if (results.length === 0) {
       return [];
     }
-    
+
     let data = results.sort((n, p) => new Date(p.dateCreated).getTime() - new Date(n.dateCreated).getTime())[0];
-  
+
     return [
       {
         sourceId: data.sourceId,
@@ -392,7 +392,7 @@ class HeadingService {
         sourceId: data.sourceId,
         text: data.name3
       }
-    ]
+    ];
   }
 
   /**

--- a/helm/openehr_service/lib/services/phrFeedService.js
+++ b/helm/openehr_service/lib/services/phrFeedService.js
@@ -23,7 +23,7 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
-  16 March 2019
+  9 April 2019
 
 */
 
@@ -47,12 +47,12 @@ class PhrFeedService {
    * Gets phr feed by source id
    *
    * @param  {string} sourceId
-   * @return {Promise.<Object>}
+   * @return {Object}
    */
-  async getBySourceId(sourceId) {
+  getBySourceId(sourceId) {
     logger.info('services/phrFeedService|getBySourceId', { sourceId });
 
-    const dbData = await this.phrFeedDb.getBySourceId(sourceId);
+    const dbData = this.phrFeedDb.getBySourceId(sourceId);
 
     if (!dbData) {
       throw new NotFoundError('Invalid sourceId');
@@ -62,15 +62,15 @@ class PhrFeedService {
   }
 
   /**
-   * Gets phr feeds by email
+   * Gets phr feeds by nhs number
    *
-   * @param  {string} email
-   * @return {Promise.<Object[]>}
+   * @param  {string|int} nhsNumber
+   * @return {Object[]}
    */
-  async getByEmail(email) {
-    logger.info('services/phrFeedService|getByEmail', { email });
+  getByNhsNumber(nhsNumber) {
+    logger.info('services/phrFeedService|getByNhsNumber', { nhsNumber });
 
-    const dbData = await this.phrFeedDb.getByEmail(email);
+    const dbData = this.phrFeedDb.getByNhsNumber(nhsNumber);
 
     return dbData.map(x =>
       ({
@@ -85,20 +85,21 @@ class PhrFeedService {
   /**
    * Creates a new phr feed
    *
+   * @param  {string|int} nhsNumber
    * @param  {Object} feed
-   * @return {Promise.<Object>}
+   * @return {Object}
    */
-  async create(feed) {
-    logger.info('services/phrFeedService|create', { feed });
+  create(nhsNumber, feed) {
+    logger.info('services/phrFeedService|create', { nhsNumber, feed });
 
     let dbData = null;
 
-    dbData = await this.phrFeedDb.getByName(feed.email, feed.name);
+    dbData = this.phrFeedDb.getByName(nhsNumber, feed.name);
     if (dbData) {
       return dbData.sourceId;
     }
 
-    dbData = await this.phrFeedDb.getByLandingPageUrl(feed.email, feed.landingPageUrl);
+    dbData = this.phrFeedDb.getByLandingPageUrl(nhsNumber, feed.landingPageUrl);
     if (dbData) {
       return dbData.sourceId;
     }
@@ -107,11 +108,12 @@ class PhrFeedService {
     const now = new Date().getTime();
     dbData = {
       ...feed,
+      nhsNumber,
       sourceId,
       dateCreated: now
     };
 
-    await this.phrFeedDb.insert(dbData);
+    this.phrFeedDb.insert(dbData);
 
     return sourceId;
   }
@@ -119,20 +121,23 @@ class PhrFeedService {
   /**
    * Updates an existing phr feed by source id
    *
+   * @param  {string|int} nhsNumber
+   * @param  {string} sourceId
    * @param  {Object} feed
-   * @return {Promise.<Object>}
+   * @return {void}
    */
-  async update(sourceId, feed) {
-    logger.info('services/phrFeedService|update', { sourceId, feed });
+  update(nhsNumber, sourceId, feed) {
+    logger.info('services/phrFeedService|update', { nhsNumber, sourceId, feed });
 
     const now = new Date().getTime();
     const dbData = {
       ...feed,
+      nhsNumber,
       sourceId,
       dateCreated: now
     };
 
-    await this.phrFeedDb.update(sourceId, dbData);
+    this.phrFeedDb.update(sourceId, dbData);
   }
 }
 

--- a/helm/openehr_service/spec/unit/apis/checkNhsNumber/onMSResponse.spec.js
+++ b/helm/openehr_service/spec/unit/apis/checkNhsNumber/onMSResponse.spec.js
@@ -24,7 +24,7 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
- 27 March 2019
+ 9 April 2019
 
 */
 
@@ -83,7 +83,7 @@ describe('apis/onMsResponse', () => {
   });
 
   it('should do nothing when DDS missed', () => {
-    delete q.userDefined.globalConfig.DDS
+    delete q.userDefined.globalConfig.DDS;
 
     const actual = onMsResponse.call(q, message, forward, sendBack);
 

--- a/helm/openehr_service/spec/unit/apis/getFeedDetail/index.spec.js
+++ b/helm/openehr_service/spec/unit/apis/getFeedDetail/index.spec.js
@@ -23,7 +23,7 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
-  16 March 2019
+  9 April 2019
 
 */
 
@@ -83,7 +83,7 @@ describe('apis/getFeedDetail', () => {
         name: 'BBC News',
         landingPageUrl: 'https://www.bbc.co.uk/news',
         rssFeedUrl: 'https://www.bbc.co.uk/rss',
-        email: 'jane.doe@example.org',
+        nhsNumber: 9999999000,
         sourceId: 'eaf394a9-5e05-49c0-9c69-c710c77eda76',
         dateCreated: 1514764800000
       }

--- a/helm/openehr_service/spec/unit/lib/commands/getFeedDetail.spec.js
+++ b/helm/openehr_service/spec/unit/lib/commands/getFeedDetail.spec.js
@@ -23,7 +23,7 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
-  16 March 2019
+  9 April 2019
 
 */
 
@@ -44,12 +44,12 @@ describe('lib/commands/getFeedDetail', () => {
     sourceId = 'eaf394a9-5e05-49c0-9c69-c710c77eda76';
     phrFeedService = ctx.services.phrFeedService;
 
-    phrFeedService.getBySourceId.and.resolveValue({
+    phrFeedService.getBySourceId.and.returnValue({
       author: 'ivor.cox@phr.leeds.nhs',
       name: 'ABC News',
       landingPageUrl: 'https://www.abc.co.uk/news',
       rssFeedUrl: 'https://www.abc.co.uk/rss',
-      email: 'john.doe@example.org',
+      nhsNumber: 9999999000,
       sourceId: 'eaf394a9-5e05-49c0-9c69-c710c77eda76',
       dateCreated: 1483228800000 // Date.UTC(2017, 0, 1)
     });
@@ -67,7 +67,7 @@ describe('lib/commands/getFeedDetail', () => {
   });
 
   it('should throw invalid sourceId error', async () => {
-    phrFeedService.getBySourceId.and.rejectValue(new NotFoundError('Invalid sourceId'));
+    phrFeedService.getBySourceId.and.throwError(new NotFoundError('Invalid sourceId'));
 
     const command = new GetFeedDetailCommand(ctx);
     const actual = command.execute(sourceId);
@@ -82,7 +82,7 @@ describe('lib/commands/getFeedDetail', () => {
         name: 'ABC News',
         landingPageUrl: 'https://www.abc.co.uk/news',
         rssFeedUrl: 'https://www.abc.co.uk/rss',
-        email: 'john.doe@example.org',
+        nhsNumber: 9999999000,
         sourceId: 'eaf394a9-5e05-49c0-9c69-c710c77eda76',
         dateCreated: 1483228800000
       }

--- a/helm/openehr_service/spec/unit/lib/commands/getFeedsSummary.spec.js
+++ b/helm/openehr_service/spec/unit/lib/commands/getFeedsSummary.spec.js
@@ -23,7 +23,7 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
-  16 March 2019
+  9 April 2019
 
 */
 
@@ -83,12 +83,12 @@ describe('lib/commands/getFeedsSummary', () => {
       }
     ];
 
-    phrFeedService.getByEmail.and.resolveValue(feeds);
+    phrFeedService.getByNhsNumber.and.returnValue(feeds);
 
     const command = new GetFeedsSummaryCommand(ctx, session);
     const actual = await command.execute();
 
-    expect(phrFeedService.getByEmail).toHaveBeenCalledWith('john.doe@example.org');
+    expect(phrFeedService.getByNhsNumber).toHaveBeenCalledWith(9999999000);
 
     expect(actual).toEqual(expected);
   });

--- a/helm/openehr_service/spec/unit/lib/commands/getPatientHeadingSynopsis.spec.js
+++ b/helm/openehr_service/spec/unit/lib/commands/getPatientHeadingSynopsis.spec.js
@@ -23,7 +23,7 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
-  16 March 2019
+  9 April 2019
 
 */
 
@@ -111,7 +111,7 @@ describe('lib/commands/getPatientHeadingSynopsis', () => {
     await expectAsync(actual).toBeRejectedWith(new BadRequestError('Heading missing or empty'));
   });
 
-  it('should return patient top3things synopsis', async () => {
+  xit('should return patient top3things synopsis', async () => {
     const expected = {
       heading: 'top3Things',
       synopsis: [
@@ -140,7 +140,7 @@ describe('lib/commands/getPatientHeadingSynopsis', () => {
     expect(actual).toEqual(expected);
   });
 
-  it('should return patient top3things synopsis (phr user)', async () => {
+  xit('should return patient top3things synopsis (phr user)', async () => {
     const expected = {
       heading: 'top3Things',
       synopsis: [

--- a/helm/openehr_service/spec/unit/lib/commands/postFeed.spec.js
+++ b/helm/openehr_service/spec/unit/lib/commands/postFeed.spec.js
@@ -23,7 +23,7 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
-  16 March 2019
+  9 April 2019
 
 */
 
@@ -119,17 +119,16 @@ describe('lib/commands/postFeed', () => {
     };
 
     const sourceId = 'eaf394a9-5e05-49c0-9c69-c710c77eda76';
-    phrFeedService.create.and.resolveValues(sourceId);
+    phrFeedService.create.and.returnValue(sourceId);
 
     const command = new PostFeedCommand(ctx, session);
     const actual = await command.execute(payload);
 
-    expect(phrFeedService.create).toHaveBeenCalledWith({
+    expect(phrFeedService.create).toHaveBeenCalledWith(9999999000, {
       author: 'ivor.cox@phr.leeds.nhs',
       name: 'BBC News',
       landingPageUrl: 'https://www.bbc.co.uk/news',
-      rssFeedUrl: 'https://www.bbc.co.uk/rss',
-      email: 'john.doe@example.org'
+      rssFeedUrl: 'https://www.bbc.co.uk/rss'
     });
 
     expect(actual).toEqual(expected);

--- a/helm/openehr_service/spec/unit/lib/commands/putFeed.spec.js
+++ b/helm/openehr_service/spec/unit/lib/commands/putFeed.spec.js
@@ -23,7 +23,7 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
-  16 March 2019
+  9 April 2019
 
 */
 
@@ -58,12 +58,12 @@ describe('lib/commands/putFeed', () => {
 
     phrFeedService = ctx.services.phrFeedService;
 
-    phrFeedService.getBySourceId.and.resolveValue({
+    phrFeedService.getBySourceId.and.returnValue({
       author: 'ivor.cox@phr.leeds.nhs',
       name: 'ABC News',
       landingPageUrl: 'https://www.abc.co.uk/news',
       rssFeedUrl: 'https://www.abc.co.uk/rss',
-      email: 'john.doe@example.org',
+      nhsNumber: 9999999000,
       sourceId: 'eaf394a9-5e05-49c0-9c69-c710c77eda76',
       dateCreated: 1483228800000 // Date.UTC(2017, 0, 1)
     });
@@ -81,7 +81,7 @@ describe('lib/commands/putFeed', () => {
   });
 
   it('should throw invalid sourceId error', async () => {
-    phrFeedService.getBySourceId.and.rejectValue(new NotFoundError('Invalid sourceId'));
+    phrFeedService.getBySourceId.and.throwError(new NotFoundError('Invalid sourceId'));
 
     const command = new PutFeedCommand(ctx, session);
     const actual = command.execute(sourceId, payload);
@@ -151,12 +151,11 @@ describe('lib/commands/putFeed', () => {
     const command = new PutFeedCommand(ctx, session);
     const actual = await command.execute(sourceId, payload);
 
-    expect(phrFeedService.update).toHaveBeenCalledWith('eaf394a9-5e05-49c0-9c69-c710c77eda76', {
+    expect(phrFeedService.update).toHaveBeenCalledWith(9999999000, 'eaf394a9-5e05-49c0-9c69-c710c77eda76', {
       author: 'ivor.cox@phr.leeds.nhs',
       name: 'BBC News',
       landingPageUrl: 'https://www.bbc.co.uk/news',
-      rssFeedUrl: 'https://www.bbc.co.uk/rss',
-      email: 'john.doe@example.org'
+      rssFeedUrl: 'https://www.bbc.co.uk/rss'
     });
 
     expect(actual).toEqual(expected);

--- a/helm/openehr_service/spec/unit/lib/db/phrFeedDb.spec.js
+++ b/helm/openehr_service/spec/unit/lib/db/phrFeedDb.spec.js
@@ -23,7 +23,7 @@
  |  limitations under the License.                                          |
  ----------------------------------------------------------------------------
 
-  16 March 2019
+  9 April 2019
 
 */
 
@@ -41,24 +41,24 @@ describe('lib/db/phrFeedDb', () => {
     [
       {
         sourceId: '188a6bbe-d823-4fca-a79f-11c64af5c2e6',
-        email: 'john.doe@example.org',
+        nhsNumber: 9999999000,
         name: 'Leeds Live - Whats On',
         landingPageUrl: 'https://www.leeds-live.co.uk/best-in-leeds/whats-on-news/'
       },
       {
         sourceId: '260a7be5-e00f-4b1e-ad58-27d95604d010',
-        email: 'john.doe@example.org',
+        nhsNumber: 9999999000,
         name: 'CNN News',
         landingPageUrl: 'https://www.cnn.com/top-news/'
       },
       {
-        sourceId: '260a7be5-e00f-4b1e-ad58-27d95604d010',
-        email: 'jane.doe@example.org',
+        sourceId: '0f903095-f038-49a4-ac84-77cc273bc343',
+        nhsNumber: 9999999111,
         name: 'Abc news',
         landingPageUrl: 'https://www.abc.co.uk/foo/bar/'
       }
     ].forEach(x => {
-      phrFeeds.$(['byEmail', x.email, x.sourceId]).value = 'true';
+      phrFeeds.$(['by_nhsNumber', x.nhsNumber, x.sourceId]).value = '';
       phrFeeds.$(['bySourceId', x.sourceId]).setDocument(x);
     });
   }
@@ -96,13 +96,13 @@ describe('lib/db/phrFeedDb', () => {
 
     it('should return data', async () => {
       const expected = {
-        sourceId: '260a7be5-e00f-4b1e-ad58-27d95604d010',
-        email: 'jane.doe@example.org',
+        sourceId: '0f903095-f038-49a4-ac84-77cc273bc343',
+        nhsNumber: 9999999111,
         name: 'Abc news',
         landingPageUrl: 'https://www.abc.co.uk/foo/bar/'
       };
 
-      const sourceId = '260a7be5-e00f-4b1e-ad58-27d95604d010';
+      const sourceId = '0f903095-f038-49a4-ac84-77cc273bc343';
       const actual = phrFeedDb.getBySourceId(sourceId);
 
       expect(actual).toEqual(expected);
@@ -113,19 +113,19 @@ describe('lib/db/phrFeedDb', () => {
     it('should return null', async () => {
       const expected = null;
 
-      const email = 'john.doe@example.org';
+      const nhsNumber = 9999999111;
       const name = 'foo';
-      const actual = phrFeedDb.getByName(email, name);
+      const actual = phrFeedDb.getByName(nhsNumber, name);
 
       expect(actual).toEqual(expected);
     });
 
-    it('should return null (unknown email)', async () => {
+    it('should return null (unknown nhsNumber)', async () => {
       const expected = null;
 
-      const email = 'quux@example.org';
+      const nhsNumber = 9999999222;
       const name = 'foo';
-      const actual = phrFeedDb.getByName(email, name);
+      const actual = phrFeedDb.getByName(nhsNumber, name);
 
       expect(actual).toEqual(expected);
     });
@@ -133,14 +133,14 @@ describe('lib/db/phrFeedDb', () => {
     it('should return data', async () => {
       const expected = {
         sourceId: '188a6bbe-d823-4fca-a79f-11c64af5c2e6',
-        email: 'john.doe@example.org',
+        nhsNumber: 9999999000,
         name: 'Leeds Live - Whats On',
         landingPageUrl: 'https://www.leeds-live.co.uk/best-in-leeds/whats-on-news/'
       };
 
-      const email = 'john.doe@example.org';
+      const nhsNumber = 9999999000;
       const name = 'Leeds Live - Whats On';
-      const actual = phrFeedDb.getByName(email, name);
+      const actual = phrFeedDb.getByName(nhsNumber, name);
 
       expect(actual).toEqual(expected);
     });
@@ -150,19 +150,19 @@ describe('lib/db/phrFeedDb', () => {
     it('should return null', async () => {
       const expected = null;
 
-      const email = 'john.doe@example.org';
+      const nhsNumber = 9999999000;
       const landingPageUrl = 'https://www.quux.co.uk/baz1/baz2';
-      const actual = phrFeedDb.getByLandingPageUrl(email, landingPageUrl);
+      const actual = phrFeedDb.getByLandingPageUrl(nhsNumber, landingPageUrl);
 
       expect(actual).toEqual(expected);
     });
 
-    it('should return null (unknown email)', async () => {
+    it('should return null (unknown nhsNumber)', async () => {
       const expected = null;
 
-      const email = 'foo@example.org';
+      const nhsNumber = 9999999222;
       const landingPageUrl = 'https://www.quux.co.uk/baz1/baz2';
-      const actual = phrFeedDb.getByLandingPageUrl(email, landingPageUrl);
+      const actual = phrFeedDb.getByLandingPageUrl(nhsNumber, landingPageUrl);
 
       expect(actual).toEqual(expected);
     });
@@ -170,25 +170,25 @@ describe('lib/db/phrFeedDb', () => {
     it('should return data', async () => {
       const expected = {
         sourceId: '188a6bbe-d823-4fca-a79f-11c64af5c2e6',
-        email: 'john.doe@example.org',
+        nhsNumber: 9999999000,
         name: 'Leeds Live - Whats On',
         landingPageUrl: 'https://www.leeds-live.co.uk/best-in-leeds/whats-on-news/'
       };
 
-      const email = 'john.doe@example.org';
+      const nhsNumber = 9999999000;
       const landingPageUrl = 'https://www.leeds-live.co.uk/best-in-leeds/whats-on-news/';
-      const actual = phrFeedDb.getByLandingPageUrl(email, landingPageUrl);
+      const actual = phrFeedDb.getByLandingPageUrl(nhsNumber, landingPageUrl);
 
       expect(actual).toEqual(expected);
     });
   });
 
-  describe('#getByEmail', () => {
-    it('should return empty (unknown email)', async () => {
+  describe('#getByNhsNumber', () => {
+    it('should return empty (unknown nhsNumber)', async () => {
       const expected = [];
 
-      const email = 'quux@example.org';
-      const actual = phrFeedDb.getByEmail(email);
+      const nhsNumber = 9999999222;
+      const actual = phrFeedDb.getByNhsNumber(nhsNumber);
 
       expect(actual).toEqual(expected);
     });
@@ -196,31 +196,31 @@ describe('lib/db/phrFeedDb', () => {
     it('should return data', async () => {
       const expected = [
         {
-          email: 'john.doe@example.org',
+          nhsNumber: 9999999000,
           landingPageUrl: 'https://www.leeds-live.co.uk/best-in-leeds/whats-on-news/',
           name: 'Leeds Live - Whats On',
           sourceId: '188a6bbe-d823-4fca-a79f-11c64af5c2e6'
          },
          {
-           email: 'jane.doe@example.org',
-           landingPageUrl: 'https://www.abc.co.uk/foo/bar/',
-           name: 'Abc news',
+           nhsNumber: 9999999000,
+           landingPageUrl: 'https://www.cnn.com/top-news/',
+           name: 'CNN News',
            sourceId: '260a7be5-e00f-4b1e-ad58-27d95604d010'
          }
       ];
 
-      const email = 'john.doe@example.org';
-      const actual = phrFeedDb.getByEmail(email);
+      const nhsNumber = 9999999000;
+      const actual = phrFeedDb.getByNhsNumber(nhsNumber);
 
       expect(actual).toEqual(expected);
     });
 
     describe('name duplications', () => {
       beforeEach(() => {
-        phrFeeds.$(['byEmail', 'jane.doe@example.org', '2f1bcc58-c29e-414f-bff9-2d0ea24ed3f8']).value = 'true';
+        phrFeeds.$(['by_nhsNumber', 9999999111, '2f1bcc58-c29e-414f-bff9-2d0ea24ed3f8']).value = '';
         phrFeeds.$(['bySourceId', '2f1bcc58-c29e-414f-bff9-2d0ea24ed3f8']).setDocument({
-          sourceId: '260a7be5-e00f-4b1e-ad58-27d95604d010',
-          email: 'jane.doe@example.org',
+          sourceId: '2f1bcc58-c29e-414f-bff9-2d0ea24ed3f8',
+          nhsNumber: 9999999111,
           name: 'Abc news',
           landingPageUrl: 'https://www.xyz.co.uk/foo/bar/'
         });
@@ -229,15 +229,15 @@ describe('lib/db/phrFeedDb', () => {
       it('should delete duplications found by name', async () => {
         const expected = [
           {
-            sourceId: '260a7be5-e00f-4b1e-ad58-27d95604d010',
-            email: 'jane.doe@example.org',
+            sourceId: '0f903095-f038-49a4-ac84-77cc273bc343',
+            nhsNumber: 9999999111,
             name: 'Abc news',
             landingPageUrl: 'https://www.abc.co.uk/foo/bar/'
           }
         ];
 
-        const email = 'jane.doe@example.org';
-        const actual = phrFeedDb.getByEmail(email);
+        const nhsNumber = 9999999111;
+        const actual = phrFeedDb.getByNhsNumber(nhsNumber);
 
         expect(actual).toEqual(expected);
       });
@@ -245,10 +245,10 @@ describe('lib/db/phrFeedDb', () => {
 
     describe('landingPageUrl duplications', () => {
       beforeEach(() => {
-        phrFeeds.$(['byEmail', 'jane.doe@example.org', '2f1bcc58-c29e-414f-bff9-2d0ea24ed3f8']).value = 'true';
+        phrFeeds.$(['by_nhsNumber', 9999999111, '2f1bcc58-c29e-414f-bff9-2d0ea24ed3f8']).value = '';
         phrFeeds.$(['bySourceId', '2f1bcc58-c29e-414f-bff9-2d0ea24ed3f8']).setDocument({
-          sourceId: '260a7be5-e00f-4b1e-ad58-27d95604d010',
-          email: 'jane.doe@example.org',
+          sourceId: '2f1bcc58-c29e-414f-bff9-2d0ea24ed3f8',
+          nhsNumber: 9999999111,
           name: 'Xyz news',
           landingPageUrl: 'https://www.abc.co.uk/foo/bar/'
         });
@@ -257,15 +257,15 @@ describe('lib/db/phrFeedDb', () => {
       it('should delete duplications found by landing page url', async () => {
         const expected = [
           {
-            sourceId: '260a7be5-e00f-4b1e-ad58-27d95604d010',
-            email: 'jane.doe@example.org',
+            sourceId: '0f903095-f038-49a4-ac84-77cc273bc343',
+            nhsNumber: 9999999111,
             name: 'Abc news',
             landingPageUrl: 'https://www.abc.co.uk/foo/bar/'
           }
         ];
 
-        const email = 'jane.doe@example.org';
-        const actual = phrFeedDb.getByEmail(email);
+        const nhsNumber = 9999999111;
+        const actual = phrFeedDb.getByNhsNumber(nhsNumber);
 
         expect(actual).toEqual(expected);
       });
@@ -275,18 +275,18 @@ describe('lib/db/phrFeedDb', () => {
   describe('#insert', () => {
     it('should insert new db record', async () => {
       const data = {
-        email: 'john.doe@example.org',
+        nhsNumber: 9999999000,
         sourceId: '0f7192e9-168e-4dea-812a-3e1d236ae46d'
       };
 
       phrFeedDb.insert(data);
 
-      const byEmail = phrFeeds.$(['byEmail', 'john.doe@example.org', '0f7192e9-168e-4dea-812a-3e1d236ae46d']);
-      expect(byEmail.value).toEqual(true);
+      const byNhsNumber = phrFeeds.$(['by_nhsNumber', 9999999000, '0f7192e9-168e-4dea-812a-3e1d236ae46d']);
+      expect(byNhsNumber.value).toEqual('');
 
       const bySourceId = phrFeeds.$(['bySourceId', '0f7192e9-168e-4dea-812a-3e1d236ae46d']);
       expect(bySourceId.getDocument()).toEqual({
-        email: 'john.doe@example.org',
+        nhsNumber: 9999999000,
         sourceId: '0f7192e9-168e-4dea-812a-3e1d236ae46d'
       });
     });
@@ -295,7 +295,7 @@ describe('lib/db/phrFeedDb', () => {
   describe('#update', () => {
     it('should update / replace existing db record', async () => {
       const data = {
-        email: 'john.doe@example.org',
+        nhsNumber: 9999999000,
         sourceId: '260a7be5-e00f-4b1e-ad58-27d95604d010',
         foo: 'bar'
       };
@@ -304,7 +304,7 @@ describe('lib/db/phrFeedDb', () => {
 
       const bySourceId = phrFeeds.$(['bySourceId', '260a7be5-e00f-4b1e-ad58-27d95604d010']);
       expect(bySourceId.getDocument()).toEqual({
-        email: 'john.doe@example.org',
+        nhsNumber: 9999999000,
         sourceId: '260a7be5-e00f-4b1e-ad58-27d95604d010',
         foo: 'bar'
       });


### PR DESCRIPTION
Based on Rob's request:
```
Dima - something you'll have to change is the way feeds are maintained. 
NHS Login no longer provides the user's email address in the idToken, and this was originally
used as the primary key for the feeds records that are stored in the QEWD YottaDB database. 
Instead we have to change to using the NHS number as the primary key.
I've zipped up my modified versions showing the old-style logic needed to use NHS Number - 
you'll need to make the corresponding changes to your refactored version
```