### PR TITLE
Added config variables for search by clinical headings

### DIFF
--- a/main/configuration/global_config.json
+++ b/main/configuration/global_config.json
@@ -71,7 +71,9 @@
         "url": "http://ethercis1.3-test.ripple.foundation:8080",
         "username": "xxxxxx",
         "password": "yyyyyyy",
-        "platform": "ethercis"
+        "platform": "ethercis",
+        "wildcard": "%",
+        "like": "like"
       }
     },
     "defaultPostHost": "ethercis",


### PR DESCRIPTION
Added config variables for correct searching by headings, those variables uses for creating correct aql file for ethercis 